### PR TITLE
Handle const diags

### DIFF
--- a/hicreppy/hicrep.py
+++ b/hicreppy/hicrep.py
@@ -270,7 +270,7 @@ def get_scc(
     weight_diag /= sum(weight_diag)
 
     # Weighted sum of coefficients to get SCCs
-    scc = np.sum(corr_diag * weight_diag)
+    scc = np.nansum(corr_diag * weight_diag)
 
     return scc
 

--- a/tests/test_hicrep.py
+++ b/tests/test_hicrep.py
@@ -11,6 +11,6 @@ MAT2 = sp.triu(sp.random(10000, 10000, density=0.05, format='coo'))
 def test_get_scc():
     max_dist = 1000
     assert np.isclose(hcr.get_scc(MAT1, MAT1, max_bins=max_dist), 1, rtol=10e-3)
-    assert np.isnan(hcr.get_scc(MAT1, sp.coo_matrix(MAT1.shape), max_bins=max_dist))
+    assert hcr.get_scc(MAT1, sp.coo_matrix(MAT1.shape), max_bins=max_dist) == 0
     assert abs(hcr.get_scc(MAT1, MAT2, max_bins=max_dist)) <= 1
 


### PR DESCRIPTION
Following suggestion from @minjaf in #5, do not propagate NaNs from individual diagonals when computing the sum of correlations across diags.